### PR TITLE
Big batch of changes (see PR description)

### DIFF
--- a/src/use/use.py
+++ b/src/use/use.py
@@ -1246,7 +1246,7 @@ If you want to auto-install the latest version: use("{name}", version="{version}
                 os.chdir(folder)
 
                 temp_sys_path = copy(sys.path)
-                sys.path = ["", list(sys.path_importer_cache)[1]]
+                # sys.path = ["", list(sys.path_importer_cache)[1], Path(json.__file__).parent.parent]
                 importlib.invalidate_caches()
                 try:
                     log.debug("Trying importlib.import_module")

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -549,7 +549,8 @@ Please consider upgrading via 'python -m pip install -U justuse'""", Use.Version
                     sorted(urls, 
                             key=lambda info: info.get("packagetype", ""))  # pre-sorting by type should ensure that we prefer binary packages over raw source
                         if Use._is_version_satisfied(info, sys_version) and
-                            Use._is_platform_compatible(info, platform_tags)
+                            Use._is_platform_compatible(info, platform_tags) and
+                            not info["yanked"]
                     ]
         if results:
             return results[0]
@@ -593,6 +594,7 @@ Please consider upgrading via 'python -m pip install -U justuse'""", Use.Version
             if not dists:
                 continue
             for info in dists:
+                if info["yanked"]: continue
                 if Use._is_version_satisfied(info, sys_version) and \
                     Use._is_platform_compatible(info, platform_tags):
                     hash_value = info["digests"].get(hash_algo)

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -925,10 +925,18 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                 path_to_url:dict=None,
                 import_to_use: dict=None,
                 fatal_exceptions:bool=False,
-                exchange_sys_path:bool=True
+                exchange_sys_path:bool=True,
+                package_name=None, module_name=None
                 ) -> ModuleType:
         initial_globals = initial_globals or {}
         aspectize = aspectize or {}
+        
+        # the whole auto-install shebang
+        if not package_name or not module_name:
+            package_name, _, module_name = name.partition(".")
+            if not module_name or not package_name:
+                package_name = module_name or package_name or name
+                module_name = module_name or package_name or name
         
         assert version is None or isinstance(version, str) or isinstance(version, Version), "Version must be given as string or packaging.version.Version."
         target_version:Version = Version(str(version)) if version else None
@@ -983,7 +991,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             if not auto_install:
                 try:
                     # feels like cheating, doesn't it
-                    mod = importlib.import_module(name)  # ! => cache
+                    mod = importlib.import_module(module_name)  # ! => cache
                     for (check, pattern), decorator in aspectize.items():
                         Use._apply_aspect(mod, check, pattern, decorator)
                     self.set_mod(name=name, mod=mod, spec=spec, path=None, frame=inspect.getframeinfo(inspect.currentframe()))
@@ -1026,7 +1034,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                     if not (version):
                         warn(Use.AmbiguityWarning("No version was provided, even though auto_install was specified! Trying to load classically installed package instead."))
                     try:
-                        mod = importlib.import_module(name)  # ! => cache
+                        mod = importlib.import_module(module_name)  # ! => cache
                         for (check, pattern), decorator in aspectize.items():
                             Use._apply_aspect(mod, check, pattern, decorator)
                         self.set_mod(name=name, mod=mod, spec=spec, path=None, frame=inspect.getframeinfo(inspect.currentframe()))
@@ -1047,11 +1055,6 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
         else:
             if not auto_install:
                 return Use._fail_or_default(default, ImportError, f"Could not find any installed package '{name}' and auto_install was not requested.")
-            
-            # the whole auto-install shebang
-            package_name, _, module_name = name.partition(".")
-            if not module_name:
-                module_name = package_name
             
             # PEBKAC
             hit:tuple = None
@@ -1246,14 +1249,14 @@ If you want to auto-install the latest version: use("{name}", version="{version}
                 os.chdir(folder)
 
                 temp_sys_path = copy(sys.path)
-                # sys.path = ["", list(sys.path_importer_cache)[1], Path(json.__file__).parent.parent]
+                sys.path = ["", list(sys.path_importer_cache)[1], Path(json.__file__).parent.parent]
                 importlib.invalidate_caches()
                 try:
                     log.debug("Trying importlib.import_module")
                     log.debug("  with cwd=%s,", os.getcwd())
                     log.debug("  sys.path=%s", sys.path)
                     
-                    mod = importlib.import_module(package_name)
+                    mod = importlib.import_module(module_name)
                 except ImportError:
                     if fatal_exceptions: raise
                     exc = traceback.format_exc()

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -138,33 +138,32 @@ def test_pure_python_package(reuse):
 
 @pytest.mark.skipif(sys.platform.startswith("win") and list(sys.version_info)[0:2] >= [3, 10],
     reason="windows Auto-installing native modules is not supported")
-def test_auto_install_native(reuse):
+def test_auto_install_native():
     rw = None
     try:
-        reuse("numpy", auto_install=True)
+        use("protobuf", auto_install=True, package_name="protobuf",
+            module_name="google.protobuf")
     except RuntimeWarning as w:
         rw = w
-    assert rw, "Expected a RuntimeWarning from unversioned auto-install"
-    match:Optional[re.Match] = re.search(
-        "use\\("
-        "\"(?P<name>.*)\", "
-        "version=\"(?P<version>.*)\", "
-        "hash_value=\"(?P<hash_value>.*)\", "
-        "auto_install=True"
-        "\\)",
-        rw.args[0]
-    )
-    assert match, f"Format did not match regex: {rw.args[0]!r}"
-    params:dict = match.groupdict()
-    name = "numpy"
-    version = params["version"]
-    hash_value = params["hash_value"]
-    print(f"calling use({name!r}, {params}, auto_install=True) ...")
-    mod = use(name, hash_value=hash_value, version=version, auto_install=True, fatal_exceptions=True)
-    print(f"mod={mod}")
-    assert mod, "No module was returned"
-    assert mod.ndarray, "Wrong module was returned (expected 'nparray')"
-    assert mod.__version__ == params["version"], "Wrong numpy version"
+        assert rw, "Expected a RuntimeWarning from unversioned auto-install"
+        match:Optional[re.Match] = re.search(
+            "use\\("
+            "\"(?P<name>.*)\", "
+            "version=\"(?P<version>.*)\", "
+            "hash_value=\"(?P<hash_value>.*)\", "
+            "auto_install=True"
+            "\\)",
+            rw.args[0]
+        )
+        assert match, f"Format did not match regex: {rw.args[0]!r}"
+        params:dict = match.groupdict()
+        version = params["version"]
+        hash_value = params["hash_value"]
+        print(f"calling use({params}, auto_install=True) ...")
+        mod = use("protobuf", version=version, hash_value=hash_value, auto_install=True, package_name="protobuf", module_name="google.protobuf")
+        print(f"mod={mod}")
+        assert mod, "No module was returned"
+        assert mod.__version__ == version
 
 def test_registry_first_line_warning(reuse):
     with open(reuse.home / "registry.json") as file:
@@ -224,28 +223,28 @@ def _extracted_from_test_registry_13(jsonfile, package_name, vers, file):
 
 def test_is_version_satisfied(reuse):
     sys_version = packaging.version.Version("3.6.0")
-    # numpy 1.19.5 normal case
-    info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'cp36', 'requires_python': '>=3.6', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
+    # google.protobuf 1.19.5 normal case
+    info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'google.protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'cp36', 'requires_python': '>=3.6', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/google.protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
     assert reuse._is_version_satisfied(info, sys_version)
     
     # requires >= python 4!
-    info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'cp36', 'requires_python': '>=4', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
+    info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'google.protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'cp36', 'requires_python': '>=4', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/google.protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
     assert not reuse._is_version_satisfied(info, sys_version)
 
     # pure python
-    info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'source', 'requires_python': '>=3.6', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
+    info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'google.protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'source', 'requires_python': '>=3.6', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/google.protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
     assert reuse._is_version_satisfied(info, sys_version)
 
 @pytest.mark.skipif(list(sys.version_info)[0:2] >= [3, 10],
-    reason="no binary distribution of numpy is available for python >= 3.10 on Windows")
+    reason="no binary distribution of google.protobuf is available for python >= 3.10 on Windows")
 def test_find_windows_artifact(reuse):
-    package_name = "numpy"
-    target_version = "1.19.5"
+    package_name = "protobuf"
+    target_version = "3.17.3"
     response = requests.get(f"https://pypi.org/pypi/{package_name}/{target_version}/json").json()
     assert reuse._find_matching_artifact(response["urls"])
 
 def test_parse_filename(reuse):
-    assert reuse._parse_filename("numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl") == {'distribution': 'numpy', 'version': '1.19.5', 'build_tag': None, 'python_tag': 'cp36', 'abi_tag': 'cp36m', 'platform_tag': 'macosx_10_9_x86_64', 'ext': 'whl'}
+    assert reuse._parse_filename("protobuf-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl") == {'distribution': 'protobuf', 'version': '1.19.5', 'build_tag': None, 'python_tag': 'cp36', 'abi_tag': 'cp36m', 'platform_tag': 'macosx_10_9_x86_64', 'ext': 'whl'}
 
 def test_classic_import_no_version(reuse):
     with warnings.catch_warnings(record=True) as w:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,56 +1,48 @@
 import json
 import os
-import re
 import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Optional
-from unittest import skip
-from unittest.mock import patch
 
-import packaging
 import pytest
+import re
 import requests
 from yarl import URL
+import packaging.tags
+import packaging.version
 
 if Path("use").is_dir(): os.chdir("..")
 import_base = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(import_base))
-
 import use
-
+__package__ = "tests"
 
 @pytest.fixture()
 def reuse():
-  # making a completely new one each time would take ages (_registry)
-  use._using = {}
-  use._aspects = {}
-  use._reloaders = {}
-  return use 
+    # making a completely new one each time would take ages (_registry)
+    use._using = {}
+    use._aspects = {}
+    use._reloaders = {}
+    return use 
 
-def get_sample_data():
-    return requests.get(
-    "https://raw.githubusercontent.com/greyblue9"
-    "/junk/master/rels.json"
-    ).json()
-
-def test_access_to_home():
-  test = use.Path.home() / ".justuse-python/packages/test"
-  test.touch(mode=0o644, exist_ok=True)
-  with open(test, "w") as file:
-    file.write("test")
-  assert test.exists()
-  test.unlink()
-  assert not test.exists()
+def test_access_to_home(reuse):
+    test = reuse.Path.home() / ".justuse-python/packages/test"
+    test.touch(mode=0o644, exist_ok=True)
+    with open(test, "w") as file:
+        file.write("test")
+    assert test.exists()
+    test.unlink()
+    assert not test.exists()
 
 def test_other_case(reuse):
-  with pytest.raises(NotImplementedError):
-    reuse(2)
+    with pytest.raises(NotImplementedError):
+        reuse(2)
 
 def test_fail_dir(reuse):
-  with pytest.raises(ImportError):
-    reuse(Path(""))
+    with pytest.raises(ImportError):
+        reuse(Path(""))
+
 def test_simple_path(reuse):
     foo_path = Path(".tests/foo.py")
     print(f"loading foo module via use(Path('{foo_path}'))")
@@ -61,107 +53,106 @@ def test_simple_url(reuse):
     import http.server
     port = 8089
     with http.server.HTTPServer(
-      ("", port), http.server.SimpleHTTPRequestHandler
+        ("", port), http.server.SimpleHTTPRequestHandler
     ) as svr:
-	    foo_uri = f"http://localhost:{port}/tests/.tests/foo.py"
-	    print(f"starting thread to handle HTTP request on port {port}")
-	    import threading
-	    thd = threading.Thread(target=svr.handle_request)
-	    thd.start()
-	    print(f"loading foo module via use(URL({foo_uri}))")
-	    with pytest.warns(use.NoValidationWarning):
-	      mod = reuse(URL(foo_uri), initial_globals={"a": 42})
-	      assert mod.test() == 42
-	    
+        foo_uri = f"http://localhost:{port}/tests/.tests/foo.py"
+        print(f"starting thread to handle HTTP request on port {port}")
+        import threading
+        thd = threading.Thread(target=svr.handle_request)
+        thd.start()
+        print(f"loading foo module via use(URL({foo_uri}))")
+        with pytest.warns(use.NoValidationWarning):
+            mod = reuse(URL(foo_uri), initial_globals={"a": 42})
+            assert mod.test() == 42
+        
 def test_internet_url(reuse):
     foo_uri = "https://raw.githubusercontent.com/greyblue9/justuse/3f783e6781d810780a4bbd2a76efdee938dde704/tests/foo.py"
     print(f"loading foo module via use(URL({foo_uri}))")
     mod = reuse(
-      URL(foo_uri), initial_globals={"a": 42},
-      hash_algo=use.Hash.sha256, hash_value="b136efa1d0dab3caaeb68bc41258525533d9058aa925d3c0c5e98ca61200674d"
+        URL(foo_uri), initial_globals={"a": 42},
+        hash_algo=use.Hash.sha256, hash_value="b136efa1d0dab3caaeb68bc41258525533d9058aa925d3c0c5e98ca61200674d"
     )
     assert mod.test() == 42
 
 def test_module_package_ambiguity(reuse):
-  original_cwd = os.getcwd()
-  os.chdir(Path("tests/.tests"))
-  with warnings.catch_warnings(record=True) as w:
-    warnings.simplefilter("always")
-    reuse("sys")
+    original_cwd = os.getcwd()
+    os.chdir(Path("tests/.tests"))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        reuse("sys")
     w_filtered = [*filter(
         lambda i: i.category is not DeprecationWarning, w)]
     assert len(w_filtered) == 1
     assert issubclass(w_filtered[-1].category, use.AmbiguityWarning)
     assert "local module" in str(w_filtered[-1].message)
-  os.chdir(original_cwd)
+    os.chdir(original_cwd)
     
 def test_builtin():
-  # must be the original use because loading builtins requires looking up _using, which mustn't be wiped for this reason 
-  mod = use("sys")
-  assert mod.path is sys.path
+    # must be the original use because loading builtins requires looking up _using, which mustn't be wiped for this reason 
+    mod = use("sys")
+    assert mod.path is sys.path
 
 def test_classical_install(reuse):
- with warnings.catch_warnings(record=True) as w:
-    warnings.simplefilter("always")
-    mod = reuse("pytest")
-    assert mod is pytest
-    assert issubclass(w[-1].category, use.AmbiguityWarning)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        mod = reuse("pytest")
+        assert mod is pytest
+        assert issubclass(w[-1].category, use.AmbiguityWarning)
 
   
 def test_autoinstall_PEBKAC(reuse):
-  # auto-install requested, but no version or hash_value specified
-  with pytest.raises(RuntimeWarning):
-    reuse("pytest", auto_install=True)
+    # auto-install requested, but no version or hash_value specified
+    with pytest.raises(RuntimeWarning):
+        reuse("pytest", auto_install=True)
   
-  # forgot hash_value
-  with pytest.raises(packaging.version.InvalidVersion):
-    reuse("pytest", auto_install=True, version="-1")
+    # forgot hash_value
+    with pytest.raises(packaging.version.InvalidVersion):
+        reuse("pytest", auto_install=True, version="-1")
   
-  # forgot version
-  with pytest.raises(RuntimeWarning):
-    reuse("pytest", auto_install=True, hash_value="asdf")
+    # forgot version
+    with pytest.raises(RuntimeWarning):
+        reuse("pytest", auto_install=True, hash_value="asdf")
     
-  # impossible version
-  with pytest.raises(AssertionError):  # version must be either str or tuple
-    reuse("pytest", auto_install=True, version=-1, hash_value="asdf")
+    # impossible version
+    with pytest.raises(AssertionError):  # version must be either str or tuple
+        reuse("pytest", auto_install=True, version=-1, hash_value="asdf")
   
-  # non-existing package
-  with pytest.raises(ImportError):
-    reuse("4-^df", auto_install=True, version="0.0.1", hash_value="asdf")
+    # non-existing package
+    with pytest.raises(ImportError):
+        reuse("4-^df", auto_install=True, version="0.0.1", hash_value="asdf")
     
 def test_version_warning(reuse):
-  # no auto-install requested, wrong version only gives a warning
-  with warnings.catch_warnings(record=True) as w:
-    warnings.simplefilter("always")
-    reuse("pytest", version="0.0")
-    assert issubclass(w[-1].category, (use.AmbiguityWarning, use.VersionWarning))
+    # no auto-install requested, wrong version only gives a warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        reuse("pytest", version="0.0")
+        assert issubclass(w[-1].category, (use.AmbiguityWarning, use.VersionWarning))
 
 def test_pure_python_package(reuse):
-  # https://pypi.org/project/example-pypi-package/
-  file = use.Path.home() / f".justuse-python/packages/example_pypi_package-0.1.0-py3-none-any.whl"
-  file.unlink(missing_ok=True)
-  test = reuse("example-pypi-package.examplepy", version="0.1.0", hash_value="ce89b1fe92abc55b4349bc58462ba255c42132598df6fe3a416a75b39b872a77", auto_install=True)
-  assert str(test.Number(2)) == "2"
-  file.unlink()
+    # https://pypi.org/project/example-pypi-package/
+    file = reuse.Path.home() / f".justuse-python/packages/example_pypi_package-0.1.0-py3-none-any.whl"
+    file.unlink(missing_ok=True)
+    test = reuse("example-pypi-package.examplepy", version="0.1.0", hash_value="ce89b1fe92abc55b4349bc58462ba255c42132598df6fe3a416a75b39b872a77", auto_install=True)
+    assert str(test.Number(2)) == "2"
+    file.unlink()
 
-@pytest.mark.skipif(sys.platform.startswith("win"),
-  reason="windows Auto-installing native modules is not supported")
-def test_auto_install_native():
-  with patch('use.config', {"debugging": True}, spec=True):  # ? not sure about that
+@pytest.mark.skipif(sys.platform.startswith("win") and list(sys.version_info)[0:2] >= [3, 10],
+    reason="windows Auto-installing native modules is not supported")
+def test_auto_install_native(reuse):
     rw = None
     try:
-      use("numpy", auto_install=True, fatal_exceptions=True)
+        reuse("numpy", auto_install=True)
     except RuntimeWarning as w:
-      rw = w
+        rw = w
     assert rw, "Expected a RuntimeWarning from unversioned auto-install"
     match:Optional[re.Match] = re.search(
-      "use\\("
+        "use\\("
         "\"(?P<name>.*)\", "
         "version=\"(?P<version>.*)\", "
         "hash_value=\"(?P<hash_value>.*)\", "
         "auto_install=True"
-      "\\)",
-      rw.args[0]
+        "\\)",
+        rw.args[0]
     )
     assert match, f"Format did not match regex: {rw.args[0]!r}"
     params:dict = match.groupdict()
@@ -176,8 +167,8 @@ def test_auto_install_native():
     assert mod.__version__ == params["version"], "Wrong numpy version"
 
 def test_registry_first_line_warning(reuse):
-  with open(reuse.home / "registry.json") as file:
-    assert file.readlines()[0].startswith("### WARNING")
+    with open(reuse.home / "registry.json") as file:
+        assert file.readlines()[0].startswith("### WARNING")
 
 def test_use_global_install(reuse):
     import foo
@@ -189,44 +180,47 @@ def test_use_global_install(reuse):
     reuse.uninstall()
     del foo
 
-def test_registry():
-  name, vers, hash = (
+def test_registry(reuse):
+    name, vers, hash_value = (
     "example-pypi-package.examplepy", "0.1.0",
     "ce89b1fe92abc55b4349bc58462ba255c42132598df6fe3a416a75b39b872a77"
-  )
-  package_name, module_name = name.split(".")
-  file = use.Path.home() / f".justuse-python" / "packages" \
-      / f"{package_name.replace('-','_')}-0.1.0-py3-none-any.whl"
-  file.unlink(missing_ok=True)
-  test = use(name, version=vers, hash_value=hash, auto_install=True)
-  with open(Path.home() / ".justuse-python" / "registry.json", "rb") \
-          as jsonfile:
-      jsonbytes = jsonfile.read()
-      jsondata = json.loads(b"\x0a".join(
-        [*filter(None,
-          filter(lambda i: not i.startswith(b"#"),
-          jsonbytes.splitlines()))]
-      ))
-      assert jsondata, "An empty registry was written to disk."
-      dists = jsondata["distributions"]
-      assert dists, "No distribution metadata saved to registry."
-      package_dists = dists[package_name]
-      assert package_dists, \
-          f"No distribution metadata saved for package {package_name}"
-      dist = package_dists[vers]
-      assert dist, "No distribution saved for the expected version."
-      assert "path" in dist, "Registry metadata contains no 'path'."
-      path = Path(dist["path"])
-      assert path.exists(), f"The package {path} did not get written."
-      assert path.absolute() == file.absolute(), \
-          f"The package did not get written to the expected location."
-      for k, v in use._registry.items():
-          jsonv = jsondata.get(k, ...)
-          if isinstance(jsonv, dict) and isinstance(v, defaultdict):
-              v = dict(v)
-          assert jsonv == v, \
-              f"The registry does not match the persisted json" \
-              f" for key '{k}': expected: {jsonv}, found: {v}"
+    )
+    package_name, _ = name.split(".")
+    file = use.Path.home() / f".justuse-python" / "packages" \
+        / f"{package_name.replace('-','_')}-0.1.0-py3-none-any.whl"
+    file.unlink(missing_ok=True)
+    _ = reuse(name, version=vers, hash_value=hash_value, auto_install=True)
+    with open(Path.home() / ".justuse-python" / "registry.json", "rb") \
+                as jsonfile:
+        _extracted_from_test_registry_13(jsonfile, package_name, vers, file)
+
+def _extracted_from_test_registry_13(jsonfile, package_name, vers, file):
+    jsonbytes = jsonfile.read()
+    jsondata = json.loads(b"\x0a".join(
+    [*filter(None,
+        filter(lambda i: not i.startswith(b"#"),
+        jsonbytes.splitlines()))]
+    ))
+    assert jsondata, "An empty registry was written to disk."
+    dists = jsondata["distributions"]
+    assert dists, "No distribution metadata saved to registry."
+    package_dists = dists[package_name]
+    assert package_dists, \
+        f"No distribution metadata saved for package {package_name}"
+    dist = package_dists[vers]
+    assert dist, "No distribution saved for the expected version."
+    assert "path" in dist, "Registry metadata contains no 'path'."
+    path = Path(dist["path"])
+    assert path.exists(), f"The package {path} did not get written."
+    assert path.absolute() == file.absolute(), \
+        f"The package did not get written to the expected location."
+    for k, v in use._registry.items():
+        jsonv = jsondata.get(k, ...)
+        if isinstance(jsonv, dict) and isinstance(v, defaultdict):
+            v = dict(v)
+        assert jsonv == v, \
+            f"The registry does not match the persisted json" \
+            f" for key '{k}': expected: {jsonv}, found: {v}"
 
 def test_is_version_satisfied(reuse):
     sys_version = packaging.version.Version("3.6.0")
@@ -242,6 +236,8 @@ def test_is_version_satisfied(reuse):
     info = {'comment_text': '', 'digests': {'md5': '2651049b70d2ec07d8afd7637f198807', 'sha256': 'cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff'}, 'downloads': -1, 'filename': 'numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'has_sig': False, 'md5_digest': '2651049b70d2ec07d8afd7637f198807', 'packagetype': 'bdist_wheel', 'python_version': 'source', 'requires_python': '>=3.6', 'size': 15599590, 'upload_time': '2021-01-05T17:19:38', 'upload_time_iso_8601': '2021-01-05T17:19:38.152665Z', 'url': 'https://files.pythonhosted.org/packages/6a/9d/984f87a8d5b28b1d4afc042d8f436a76d6210fb582214f35a0ea1db3be66/numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl', 'yanked': False, 'yanked_reason': None}
     assert reuse._is_version_satisfied(info, sys_version)
 
+@pytest.mark.skipif(list(sys.version_info)[0:2] >= [3, 10],
+    reason="no binary distribution of numpy is available for python >= 3.10 on Windows")
 def test_find_windows_artifact(reuse):
     package_name = "numpy"
     target_version = "1.19.5"
@@ -252,35 +248,33 @@ def test_parse_filename(reuse):
     assert reuse._parse_filename("numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl") == {'distribution': 'numpy', 'version': '1.19.5', 'build_tag': None, 'python_tag': 'cp36', 'abi_tag': 'cp36m', 'platform_tag': 'macosx_10_9_x86_64', 'ext': 'whl'}
 
 def test_classic_import_no_version(reuse):
- with warnings.catch_warnings(record=True) as w:
-    warnings.simplefilter("always")
-    mod = reuse("mmh3", fatal_exceptions=True)
-    assert issubclass(w[-1].category, reuse.AmbiguityWarning)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        _ = reuse("mmh3", fatal_exceptions=True)
+        assert issubclass(w[-1].category, reuse.AmbiguityWarning)
 
 def test_classic_import_same_version(reuse):
- version = reuse.Version(__import__("mmh3").__version__)
- with warnings.catch_warnings(record=True) as w:
-    warnings.simplefilter("always")
-    mod = reuse("mmh3", version=version, fatal_exceptions=True)
-    assert not w
-    assert reuse.Version(mod.__version__) == version
+    version = reuse.Version(__import__("mmh3").__version__)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        mod = reuse("mmh3", version=version, fatal_exceptions=True)
+        assert not w
+        assert reuse.Version(mod.__version__) == version
 
 def test_classic_import_diff_version(reuse):
- version = reuse.Version(__import__("mmh3").__version__)
- with warnings.catch_warnings(record=True) as w:
-    warnings.simplefilter("always")
-    major, minor, patch = version
-    mod = reuse("mmh3", version=reuse.Version(major=major, minor=minor, patch=patch +1), fatal_exceptions=True)
-    assert issubclass(w[-1].category, reuse.VersionWarning)
-    assert reuse.Version(mod.__version__) == version
+    version = reuse.Version(__import__("mmh3").__version__)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        major, minor, patch = version
+        mod = reuse("mmh3", version=reuse.Version(major=major, minor=minor, patch=patch +1), fatal_exceptions=True)
+        assert issubclass(w[-1].category, reuse.VersionWarning)
+        assert reuse.Version(mod.__version__) == version
 
 def test_use_ugrade_version_warning(reuse):
     version = "0.0.0"
-    with warnings.catch_warnings(record=True) as w: 
+    with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        # no other way to change __version__ before the actual import
-        # while the version check happens on import
-        test_use = reuse(reuse.Path("../src/use/use.py"),
-            initial_globals={"test_version":version})
+        # no other way to change __version__ before the actual import while the version check happens on import
+        test_use = reuse(reuse.Path("../src/use/use.py"), initial_globals={"test_version":version})
         assert test_use.test_version == test_use.__version__ == version
         assert w[0].category.__name__ == reuse.VersionWarning.__name__


### PR DESCRIPTION
- Skip yanked artifacts when returning latest version / compatible artifacts
- Use protobuf for native module test because it doesn't have a tree of additional dependencies we don't auto_install
- Whitespace, remove unused imports, make lint happy as suggested by PyDev, Tabnine
- Test fixes:
    - Two tests cannot run on Windows if python >= 3.10
    - Adjustments to native test (don't check for 'ndarray' etc.)