### PR TITLE
Peoxy mod changes, CI cleanups and fixes, source_dir edge case

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,25 +18,12 @@ jobs:
         run: |
           export FTP_USER="${{ secrets.FTP_USER }}"
           export FTP_PASS="${{ secrets.FTP_PASS }}"
-          [ -e tests/coverage.sh ] && bash ./tests/coverage.sh
-          [ -e tests/coverage.sh ] || {
-            python3 -m pip install anyio mmh3 mypy packaging pip pytest pytest-env pytest-cov requests types-toml
-            python3 -m pytest
+          mkdir -p ~/.justuse-python/
+          echo "debug = true" > ~/.justuse-python/config.toml
+          [ -e tests/coverage.sh ] && bash tests/coverage.sh || {
+          python3 -m pip install anyio mmh3 mypy packaging pip pytest pytest-env pytest-cov requests types-toml types-requests furl yarl
+          DEBUG=1 VERBOSE=1 TRACE=1 PYTHONDEBUGMODE=1 PYTHONDONTWRITEBYTECODE=1 python3 -m pytest
           }
-      - name: Genetate coverage badge
-        uses: tj-actions/coverage-badge-py@v1.6
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-          github-token: ${{ secrets.PAT_TOKEN }}
-          repository: amogorkon/justuse
-          authentication: bearer ${{ secrets.PAT_TOKEN }}
-      - name: Upload coverage badge
-        run: |
-          export GITHUB_TOKEN="${{ secrets.PAT_TOKEN }}"
-          export GITHUB_PAT_TOKEN="${{ secrets.PAT_TOKEN }}"
-          export FTP_USER="${{ secrets.FTP_USER }}"
-          export FTP_PASS="${{ secrets.FTP_PASS }}"
-          bash tests/coverage.sh upload || true
 
   test-windows:
     runs-on: windows-latest

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -376,18 +376,14 @@ class Use(ModuleType):
         )  # {(name -> interval_tree of Version -> function} basically plugins/workarounds for specific packages/versions
 
         self._set_up_files_and_directories()
-        # might run into issues during testing otherwise
-        if not test_version:
-            try:
-                self.registry = sqlite3.connect(self.home / "registry.db")
-                self.registry.execute("PRAGMA foreign_keys=ON")
-                self.registry.execute("PRAGMA auto_vacuum = FULL")
-            except Exception as e:
-                raise RuntimeError(
-                    f"Could not connect to the registry database, please make sure it is accessible. ({e})"
-                )
-        else:
-            self.registry = sqlite3.connect(":memory:")
+        try:
+            self.registry = sqlite3.connect(self.home / "registry.db").cursor()
+            self.registry.execute("PRAGMA foreign_keys=ON")
+            self.registry.execute("PRAGMA auto_vacuum = FULL")
+        except Exception as e:
+            raise RuntimeError(
+                f"Could not connect to the registry database, please make sure it is accessible. ({e})"
+            )
         self._set_up_registry()
         assert self.registry is not None, "Registry is None"
         self._registry = Use._load_registry(self.home / "registry.json")
@@ -622,7 +618,7 @@ CREATE TABLE IF NOT EXISTS "depends_on" (
         ).fetchall():
             if not Path(path).exists():
                 self.registry.execute(f"DELETE FROM distributions WHERE id=?", (ID,))
-        self.registry.commit()
+        self.registry.connection.commit()
 
     def _save_module_info(
         self,
@@ -659,28 +655,28 @@ CREATE TABLE IF NOT EXISTS "depends_on" (
             }
         )
         if not (
-            ID := (cursor := self.registry.execute(
+            ID := self.registry.execute(
                 f"SELECT * FROM distributions WHERE name=? AND version=?",
                 (package_name, version),
-            )).fetchone()
+            ).fetchone()
         ):
-            cursor = self.registry.execute(
+            self.registry.execute(
                 f"""
 INSERT INTO distributions (name, version, installation_path, date_of_installation, pure_python_package)
 VALUES ('{name}', '{version}', '{folder}', {time.time()}, {folder is None})
 """
             )
-            cursor = self.registry.execute(
+            self.registry.execute(
                 f"""
 INSERT INTO artifacts (distribution_id, path)
-VALUES ({cursor.lastrowid}, '{path}')
+VALUES ({self.registry.lastrowid}, '{path}') 
 """
             )
-            cursor = self.registry.execute(
-                f""" INSERT OR IGNORE INTO hashes (artifact_id, algo, value)
-                                  VALUES ({cursor.lastrowid}, '{hash_algo.name}', '{that_hash}')"""
+            self.registry.execute(
+                f""" INSERT INTO hashes (artifact_id, algo, value)
+                                  VALUES ({self.registry.lastrowid}, '{hash_algo.name}', '{that_hash}')"""
             )
-        self.registry.commit()
+        self.registry.connection.commit()
 
     def _set_mod(self, *, name, mod, frame, path=None, spec=None):
         """Helper to get the order right."""
@@ -1773,6 +1769,9 @@ Use.config = config
 Use.mode = mode
 Use.Path = Path
 Use.URL = URL
+Use.__doc__ = __doc__
+Use.__version__ = __version__
+Use.__name__ = __name__
 Use.__path__ = str(Path(__file__).resolve().parent)
 
 use = Use()

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -376,14 +376,18 @@ class Use(ModuleType):
         )  # {(name -> interval_tree of Version -> function} basically plugins/workarounds for specific packages/versions
 
         self._set_up_files_and_directories()
-        try:
-            self.registry = sqlite3.connect(self.home / "registry.db").cursor()
-            self.registry.execute("PRAGMA foreign_keys=ON")
-            self.registry.execute("PRAGMA auto_vacuum = FULL")
-        except Exception as e:
-            raise RuntimeError(
-                f"Could not connect to the registry database, please make sure it is accessible. ({e})"
-            )
+        # might run into issues during testing otherwise
+        if not test_version:
+            try:
+                self.registry = sqlite3.connect(self.home / "registry.db").cursor()
+                self.registry.execute("PRAGMA foreign_keys=ON")
+                self.registry.execute("PRAGMA auto_vacuum = FULL")
+            except Exception as e:
+                raise RuntimeError(
+                    f"Could not connect to the registry database, please make sure it is accessible. ({e})"
+                )
+        else:
+            self.registry = sqlite3.connect(":memory:")
         self._set_up_registry()
         assert self.registry is not None, "Registry is None"
         self._registry = Use._load_registry(self.home / "registry.json")
@@ -1769,9 +1773,6 @@ Use.config = config
 Use.mode = mode
 Use.Path = Path
 Use.URL = URL
-Use.__doc__ = __doc__
-Use.__version__ = __version__
-Use.__name__ = __name__
 Use.__path__ = str(Path(__file__).resolve().parent)
 
 use = Use()

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -236,7 +236,7 @@ class ProxyModule(ModuleType):
         self.__condition = threading.RLock()
 
     def __getattribute__(self, name):
-        if name in ("_ProxyModule__implementation", "_ProxyModule__condition", ""):
+        if name in ("_ProxyModule__implementation", "_ProxyModule__condition", "", "__class__", "__metaclass__", "__instancecheck__"):
             return object.__getattribute__(self, name)
         with self.__condition:
             return getattr(self.__implementation, name)
@@ -331,6 +331,11 @@ class ModuleReloader:
 
 # an instance of types.ModuleType
 class Use(ModuleType):
+    __name__ = __name__
+    __file__ = __file__
+    __spec__ = __spec__
+    Use = property(lambda _: Use)
+
     class Hash(Enum):
         sha256 = hashlib.sha256
 
@@ -1051,6 +1056,18 @@ VALUES ({cursor.lastrowid}, '{path}')
                 thing.__dict__[name] = decorator(obj)
         return thing
 
+    @staticmethod
+    def _ensure_proxy(mod):
+        log.debug("_ensure_proxy(%s) is a %s", mod,
+            mod.__class__.__qualname__)
+        if mod.__class__ is not ModuleType:
+            log.debug("_ensure_proxy(%s): isinstance -> True", mod)
+            return mod
+        new_mod = ProxyModule(mod)
+        log.debug("_ensure_proxy(%s): new_mod = %s, is a %s", mod,
+            new_mod, new_mod.__class__.__qualname__)
+        return new_mod
+
     @methdispatch
     def __call__(self, thing, /, *args, **kwargs):
         raise NotImplementedError(
@@ -1122,7 +1139,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             ), f"as_import must be the name (as str) of the module as which it should be imported, got {as_import} ({type(as_import)}) instead."
             assert as_import.isidentifier(), "as_import must be a valid identifier."
             sys.modules[as_import] = mod
-        return mod
+        return self._ensure_proxy(mod)
 
     @__call__.register(Path)
     def _use_path(
@@ -1179,6 +1196,10 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                             .resolve()
                             .parent
                         )
+            if source_dir is None:
+                source_dir = Path(main_mod.__loader__.path).parent
+            if not source_dir.joinpath(path).exists():
+                source_dir = Path.cwd()
             if not source_dir.exists():
                 return Use._fail_or_default(
                     default,
@@ -1271,7 +1292,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             sys.modules[as_import] = mod
         frame = inspect.getframeinfo(inspect.currentframe())
         self._set_mod(name=name, mod=mod, frame=frame)
-        return mod
+        return self._ensure_proxy(mod)
 
     def _import_builtin(self, name, spec, default, aspectize):
         try:
@@ -1288,7 +1309,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                 )
             frame = inspect.getframeinfo(inspect.currentframe())
             self._set_mod(name=name, mod=mod, spec=spec, frame=frame)
-            return mod
+            return self._ensure_proxy(mod)
         except:
             exc = traceback.format_exc()
             return Use._fail_or_default(default, ImportError, exc)
@@ -1376,7 +1397,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             )
         frame = inspect.getframeinfo(inspect.currentframe())
         self._set_mod(name=name, mod=mod, frame=frame)
-        return mod
+        return self._ensure_proxy(mod)
 
     @__call__.register(str)
     def _use_str(
@@ -1504,7 +1525,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                         f'Classically imported \'{name}\'. To pin this version: use("{name}", version="{this_version}")',
                         Use.AmbiguityWarning,
                     )
-                    return mod
+                    return self._ensure_proxy(mod)
                 # wrong version => wrong spec
                 this_version = Use._get_version(mod=mod)
                 if this_version != target_version:
@@ -1725,7 +1746,7 @@ If you want to auto-install the latest version: use("{name}", version="{version}
                     fatal_exceptions=fatal_exceptions,
                     module_name=module_name,
                 )
-                return mod
+                return self._ensure_proxy(mod)
 
             # trying to import directly from zip
             try:
@@ -1760,7 +1781,7 @@ If you want to auto-install the latest version: use("{name}", version="{version}
             name, this_version, url, path, that_hash, folder, package_name=package_name
         )
         self.persist_registry()
-        return mod
+        return self._ensure_proxy(mod)
 
     pass
 
@@ -1774,6 +1795,8 @@ Use.mode = mode
 Use.Path = Path
 Use.URL = URL
 Use.__path__ = str(Path(__file__).resolve().parent)
+Use.__name__ = __name__
+
 
 use = Use()
 if not test_version:

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -379,7 +379,7 @@ class Use(ModuleType):
         # might run into issues during testing otherwise
         if not test_version:
             try:
-                self.registry = sqlite3.connect(self.home / "registry.db").cursor()
+                self.registry = sqlite3.connect(self.home / "registry.db")
                 self.registry.execute("PRAGMA foreign_keys=ON")
                 self.registry.execute("PRAGMA auto_vacuum = FULL")
             except Exception as e:
@@ -622,7 +622,7 @@ CREATE TABLE IF NOT EXISTS "depends_on" (
         ).fetchall():
             if not Path(path).exists():
                 self.registry.execute(f"DELETE FROM distributions WHERE id=?", (ID,))
-        self.registry.connection.commit()
+        self.registry.commit()
 
     def _save_module_info(
         self,
@@ -659,28 +659,28 @@ CREATE TABLE IF NOT EXISTS "depends_on" (
             }
         )
         if not (
-            ID := self.registry.execute(
+            ID := (cursor := self.registry.execute(
                 f"SELECT * FROM distributions WHERE name=? AND version=?",
                 (package_name, version),
-            ).fetchone()
+            )).fetchone()
         ):
-            self.registry.execute(
+            cursor = self.registry.execute(
                 f"""
 INSERT INTO distributions (name, version, installation_path, date_of_installation, pure_python_package)
 VALUES ('{name}', '{version}', '{folder}', {time.time()}, {folder is None})
 """
             )
-            self.registry.execute(
+            cursor = self.registry.execute(
                 f"""
 INSERT INTO artifacts (distribution_id, path)
-VALUES ({self.registry.lastrowid}, '{path}') 
+VALUES ({cursor.lastrowid}, '{path}')
 """
             )
-            self.registry.execute(
+            cursor = self.registry.execute(
                 f""" INSERT INTO hashes (artifact_id, algo, value)
-                                  VALUES ({self.registry.lastrowid}, '{hash_algo.name}', '{that_hash}')"""
+                                  VALUES ({cursor.lastrowid}, '{hash_algo.name}', '{that_hash}')"""
             )
-        self.registry.connection.commit()
+        self.registry.commit()
 
     def _set_mod(self, *, name, mod, frame, path=None, spec=None):
         """Helper to get the order right."""

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -677,7 +677,7 @@ VALUES ({cursor.lastrowid}, '{path}')
 """
             )
             cursor = self.registry.execute(
-                f""" INSERT INTO hashes (artifact_id, algo, value)
+                f""" INSERT OR IGNORE INTO hashes (artifact_id, algo, value)
                                   VALUES ({cursor.lastrowid}, '{hash_algo.name}', '{that_hash}')"""
             )
         self.registry.commit()

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -18,6 +18,7 @@ if [ "x$GITHUB_AUTH$GITHUB_PATH$GITHUB_ROOT$GITHUB_USER$GITHUB_AUTHOR$GITHUB_REP
   
   yes y | $PYTHON3 -m pip install --force-reinstall --upgrade \
           -r requirements.txt
+  yes y | $PYTHON3 -m pip install --force-reinstall --upgrade pytest-cov pytest-env coverage coverage-badge
   which busybox 2>/dev/null || {
     if which apt; then
       apt install -y busybox || sudo apt install -y busybox

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -40,12 +40,13 @@ echo "cfile=${cfile}" 1>&2
 cdir="${cfile%/?*}"
 cd "$cdir"
 set +e
-default="/home/runner/work/justuse/justuse/coverage.svg"
+BADGE_FILENAME="coverage.svg"
+default="/home/runner/work/justuse/justuse/$BADGE_FILENAME"
 f="$default"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
 if [ -d "$dir" ]; then
   :
 else
-  default="$PWD/coverage/justuse-coverage-badge.svg"
+  default="$PWD/coverage/justuse-$BADGE_FILENAME"
 fi
 echo "default=$default" 1>&2
 file="$default"

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-arg1="$1"
 
 [ -d use -a -f use/use.py ] && cd ..
 [ -f unit_teat.py ] && cd ..
@@ -145,13 +144,7 @@ f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
 mkdir -p "$dir"
 python3 -m coverage_badge | tee "$file"
 echo "Found an image to publish: [$file]" 1>&2
-for variant in \
-    '"/public_html/mixed/$fn" "$file"'  \
-    ;  \
-do
-    eval "set -- $variant"
-    cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
-          ftp.pinproject.com "$@"  )
+cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" "/public_html/mixed/$fn" "$file" )
     echo -E "Trying variant:" 1>&2
     if (( ! UID )); then
       echo "$@" 1>&2
@@ -161,7 +154,6 @@ do
     if (( ! rs )); then
         break
     fi
-done
 [ $rs -eq 0 ] && echo "*** Image upload succeeded: $file ***" 1>&2 
 
 exit ${rs:-0} # upload

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -121,7 +121,8 @@ def test_classical_install(reuse):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         mod = reuse("pytest", modes=reuse.fatal_exceptions)
-        assert mod is pytest
+        assert mod is pytest or \
+               mod._ProxyModule__implementation is pytest
         assert issubclass(w[-1].category, use.AmbiguityWarning)
 
 
@@ -173,8 +174,9 @@ def test_pure_python_package(reuse):
     # https://pypi.org/project/example-pypi-package/
     file = (
         reuse.Path.home()
-        / f".justuse-python/packages/example_pypi_package-0.1.0-py3-none-any.whl"
+        / '.justuse-python/packages/example_pypi_package-0.1.0-py3-none-any.whl'
     )
+
     file.unlink(missing_ok=True)
     test = reuse(
         "example-pypi-package.examplepy",
@@ -298,11 +300,9 @@ def test_registry(reuse):
     )
     package_name, _ = name.split(".")
     file = (
-        use.Path.home()
-        / f".justuse-python"
-        / "packages"
-        / f"{package_name.replace('-','_')}-0.1.0-py3-none-any.whl"
-    )
+        (use.Path.home() / '.justuse-python') / "packages"
+    ) / f"{package_name.replace('-','_')}-0.1.0-py3-none-any.whl"
+
     file.unlink(missing_ok=True)
     mod = reuse(
         name,
@@ -340,7 +340,7 @@ def _extracted_from_test_registry_13(jsonfile, package_name, vers, file):
     assert path.exists(), f"The package {path} did not get written."
     assert (
         path.absolute() == file.absolute()
-    ), f"The package did not get written to the expected location."
+    ), 'The package did not get written to the expected location.'
     for k, v in use._registry.items():
         jsonv = jsondata.get(k, ...)
         if isinstance(jsonv, dict) and isinstance(v, defaultdict):
@@ -528,7 +528,7 @@ def test_suggestion_works(reuse):
     except RuntimeWarning as rw:
         match = re.search(r"(use\(.*\))", str(rw))
         assert match
-        log.info(f"eval(match[1]!r)")
+        log.info('eval(match[1]!r)')
         mod = eval(match[1])
         assert mod
         return


### PR DESCRIPTION
Peoxy mod changes and source_dir edge case:
    * Add __name__ and friends to Use module instance (#156)
    * Make the class 'use.Use' accessible
    * Make the original module 'use.use' accessible
    * Fix null source dir encountered in REPL
    * Return ProxyModule where we return 'mod' from an instance method' (#156)
    * Fix failing assert
    * 'Refactored by Sourcery' (#157)

Unit Test/CI infra Tidy-ups and Fixes:
  * Fix coverage badge issues
  * Strip unnecessary code from CI workflow file
  * Address two shell script refactorings

As previously merged (via branch '83-we-should-turn-the-registry-into-an-sqlite-db'):
  * work on sqlite (amogorkon/justuse#1)
  * in-memory db for testing
  * Fix _using key and self._registry = Cursor/Connection
  * Insert/ignore for duplicate hashes

Co-authored-by: Anselm Kiefner <use-github@anselm.kiefner.de>
Co-authored-by: David Reilly <greyblue9@gmail.com>