### PR TITLE
ProxyModule preparation, CI cleanups and fixes, source_dir edge case

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -28,11 +28,6 @@ on:
     types: [published, updated]
   release:
     types: [published, unpublished, created, edited, deleted, prereleased, released]
-  pull_request:
-    types: [opened, edited, closed]
-  push:
-  release:
-    types: [published, created, edited, released]
 
 jobs:
   test-ubuntu:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -41,9 +41,9 @@ jobs:
           export FTP_PASS="${{ secrets.FTP_PASS }}"
           mkdir -p ~/.justuse-python/
           echo "debug = true" > ~/.justuse-python/config.toml
+          python3 -m pip install --force-reinstall anyio mmh3 mypy packaging pip pytest pytest-env pytest-cov requests types-toml types-requests furl yarl coverage coverage-badge
           [ -e tests/coverage.sh ] && bash tests/coverage.sh || {
-          python3 -m pip install anyio mmh3 mypy packaging pip pytest pytest-env pytest-cov requests types-toml types-requests furl yarl
-          DEBUG=1 VERBOSE=1 TRACE=1 PYTHONDEBUGMODE=1 PYTHONDONTWRITEBYTECODE=1 python3 -m pytest
+            python3 -m pytest
           }
 
   test-windows:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,25 +18,12 @@ jobs:
         run: |
           export FTP_USER="${{ secrets.FTP_USER }}"
           export FTP_PASS="${{ secrets.FTP_PASS }}"
-          [ -e tests/coverage.sh ] && bash ./tests/coverage.sh
-          [ -e tests/coverage.sh ] || {
-            python3 -m pip install anyio mmh3 mypy packaging pip pytest pytest-env pytest-cov requests types-toml
-            python3 -m pytest
+          mkdir -p ~/.justuse-python/
+          echo "debug = true" > ~/.justuse-python/config.toml
+          [ -e tests/coverage.sh ] && bash tests/coverage.sh || {
+          python3 -m pip install anyio mmh3 mypy packaging pip pytest pytest-env pytest-cov requests types-toml types-requests furl yarl
+          DEBUG=1 VERBOSE=1 TRACE=1 PYTHONDEBUGMODE=1 PYTHONDONTWRITEBYTECODE=1 python3 -m pytest
           }
-      - name: Genetate coverage badge
-        uses: tj-actions/coverage-badge-py@v1.6
-        with:
-          token: ${{ secrets.PAT_TOKEN }}
-          github-token: ${{ secrets.PAT_TOKEN }}
-          repository: amogorkon/justuse
-          authentication: bearer ${{ secrets.PAT_TOKEN }}
-      - name: Upload coverage badge
-        run: |
-          export GITHUB_TOKEN="${{ secrets.PAT_TOKEN }}"
-          export GITHUB_PAT_TOKEN="${{ secrets.PAT_TOKEN }}"
-          export FTP_USER="${{ secrets.FTP_USER }}"
-          export FTP_PASS="${{ secrets.FTP_PASS }}"
-          bash tests/coverage.sh upload || true
 
   test-windows:
     runs-on: windows-latest

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,7 +1,33 @@
 name: Unit Tests
 
 on:
+  check_run:
+    types: [created, rerequested, completed]
+  check_suite:
+    types: [completed, requested, rerequested]
+  create:
+  delete:
+  deployment:
+  deployment_status:
   fork:
+  gollum:
+  page_build:
+  project:
+    types: [created, updated, closed, reopened, edited, deleted]
+  public:
+  pull_request:
+    types: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, ready_for_review, locked, unlocked, review_requested, review_request_removed]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  pull_request_target:
+    types: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, ready_for_review, locked, unlocked, review_requested, review_request_removed]
+  push:
+  registry_package:
+    types: [published, updated]
+  release:
+    types: [published, unpublished, created, edited, deleted, prereleased, released]
   pull_request:
     types: [opened, edited, closed]
   push:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![Downloads](https://pepy.tech/badge/justuse)](https://pepy.tech/project/justuse)
 [![justuse](https://snyk.io/advisor/python/justuse/badge.svg)](https://snyk.io/advisor/python/justuse)
 [![slack](https://img.shields.io/badge/slack-@justuse-purple.svg?logo=slack)](https://join.slack.com/t/justuse/shared_invite/zt-tot4bhq9-_qIXBdeiRIfhoMjxu0EhFw)
-[![coverage](http://pinproject.com/mixed/coverage_greyblue9-justuse.main.svg)](https://github.com/amogorkon/justuse/avtions)
-[![CI Pipeline](https://github.com/greyblue9/justuse/actions/workflows/blank.yml/badge.svg)](https://github.com/greyblue9/justuse/actions/workflows/blank.yml)
+[![coverage](http://pinproject.com/mixed/coverage.svg)](https://github.com/amogorkon/justuse/avtions)
 
 # Just use() python the way you want!
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Downloads](https://pepy.tech/badge/justuse)](https://pepy.tech/project/justuse)
 [![justuse](https://snyk.io/advisor/python/justuse/badge.svg)](https://snyk.io/advisor/python/justuse)
 [![slack](https://img.shields.io/badge/slack-@justuse-purple.svg?logo=slack)](https://join.slack.com/t/justuse/shared_invite/zt-tot4bhq9-_qIXBdeiRIfhoMjxu0EhFw)
-[![coverage](http://pinproject.com/mixed/coverage.svg)](https://github.com/amogorkon/justuse/avtions)
+[![coverage](http://pinproject.com/mixed/coverage_greyblue9-justuse.main.svg)](https://github.com/amogorkon/justuse/avtions)
 
 # Just use() python the way you want!
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![justuse](https://snyk.io/advisor/python/justuse/badge.svg)](https://snyk.io/advisor/python/justuse)
 [![slack](https://img.shields.io/badge/slack-@justuse-purple.svg?logo=slack)](https://join.slack.com/t/justuse/shared_invite/zt-tot4bhq9-_qIXBdeiRIfhoMjxu0EhFw)
 [![coverage](http://pinproject.com/mixed/coverage_greyblue9-justuse.main.svg)](https://github.com/amogorkon/justuse/avtions)
+[![CI Pipeline](https://github.com/greyblue9/justuse/actions/workflows/blank.yml/badge.svg)](https://github.com/greyblue9/justuse/actions/workflows/blank.yml)
 
 # Just use() python the way you want!
 

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -236,7 +236,7 @@ class ProxyModule(ModuleType):
         self.__condition = threading.RLock()
 
     def __getattribute__(self, name):
-        if name in ("_ProxyModule__implementation", "_ProxyModule__condition", ""):
+        if name in ("_ProxyModule__implementation", "_ProxyModule__condition", "", "__class__", "__metaclass__", "__instancecheck__"):
             return object.__getattribute__(self, name)
         with self.__condition:
             return getattr(self.__implementation, name)
@@ -331,6 +331,11 @@ class ModuleReloader:
 
 # an instance of types.ModuleType
 class Use(ModuleType):
+    __name__ = __name__
+    __file__ = __file__
+    __spec__ = __spec__
+    Use = property(lambda _: Use)
+
     class Hash(Enum):
         sha256 = hashlib.sha256
 
@@ -1051,6 +1056,18 @@ VALUES ({cursor.lastrowid}, '{path}')
                 thing.__dict__[name] = decorator(obj)
         return thing
 
+    @staticmethod
+    def _ensure_proxy(mod):
+        log.debug("_ensure_proxy(%s) is a %s", mod,
+            mod.__class__.__qualname__)
+        if mod.__class__ is not ModuleType:
+            log.debug("_ensure_proxy(%s): isinstance -> True", mod)
+            return mod
+        new_mod = ProxyModule(mod)
+        log.debug("_ensure_proxy(%s): new_mod = %s, is a %s", mod,
+            new_mod, new_mod.__class__.__qualname__)
+        return new_mod
+
     @methdispatch
     def __call__(self, thing, /, *args, **kwargs):
         raise NotImplementedError(
@@ -1122,7 +1139,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             ), f"as_import must be the name (as str) of the module as which it should be imported, got {as_import} ({type(as_import)}) instead."
             assert as_import.isidentifier(), "as_import must be a valid identifier."
             sys.modules[as_import] = mod
-        return mod
+        return self._ensure_proxy(mod)
 
     @__call__.register(Path)
     def _use_path(
@@ -1179,6 +1196,10 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                             .resolve()
                             .parent
                         )
+            if source_dir is None:
+                source_dir = Path(main_mod.__loader__.path).parent
+            if not source_dir.joinpath(path).exists():
+                source_dir = Path.cwd()
             if not source_dir.exists():
                 return Use._fail_or_default(
                     default,
@@ -1271,7 +1292,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             sys.modules[as_import] = mod
         frame = inspect.getframeinfo(inspect.currentframe())
         self._set_mod(name=name, mod=mod, frame=frame)
-        return mod
+        return self._ensure_proxy(mod)
 
     def _import_builtin(self, name, spec, default, aspectize):
         try:
@@ -1288,7 +1309,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                 )
             frame = inspect.getframeinfo(inspect.currentframe())
             self._set_mod(name=name, mod=mod, spec=spec, frame=frame)
-            return mod
+            return self._ensure_proxy(mod)
         except:
             exc = traceback.format_exc()
             return Use._fail_or_default(default, ImportError, exc)
@@ -1376,7 +1397,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
             )
         frame = inspect.getframeinfo(inspect.currentframe())
         self._set_mod(name=name, mod=mod, frame=frame)
-        return mod
+        return self._ensure_proxy(mod)
 
     @__call__.register(str)
     def _use_str(
@@ -1504,7 +1525,7 @@ To safely reproduce: use(use.URL('{url}'), hash_algo=use.{hash_algo}, hash_value
                         f'Classically imported \'{name}\'. To pin this version: use("{name}", version="{this_version}")',
                         Use.AmbiguityWarning,
                     )
-                    return mod
+                    return self._ensure_proxy(mod)
                 # wrong version => wrong spec
                 this_version = Use._get_version(mod=mod)
                 if this_version != target_version:
@@ -1725,7 +1746,7 @@ If you want to auto-install the latest version: use("{name}", version="{version}
                     fatal_exceptions=fatal_exceptions,
                     module_name=module_name,
                 )
-                return mod
+                return self._ensure_proxy(mod)
 
             # trying to import directly from zip
             try:
@@ -1760,7 +1781,7 @@ If you want to auto-install the latest version: use("{name}", version="{version}
             name, this_version, url, path, that_hash, folder, package_name=package_name
         )
         self.persist_registry()
-        return mod
+        return self._ensure_proxy(mod)
 
     pass
 
@@ -1774,6 +1795,8 @@ Use.mode = mode
 Use.Path = Path
 Use.URL = URL
 Use.__path__ = str(Path(__file__).resolve().parent)
+Use.__name__ = __name__
+
 
 use = Use()
 if not test_version:

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -144,7 +144,7 @@ f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
 mkdir -p "$dir"
 python3 -m coverage_badge | tee "$file"
 echo "Found an image to publish: [$file]" 1>&2
-cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" "/public_html/mixed/$fn" "$file" )
+cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" "$file" "/public_html/mixed/$fn" )
     echo -E "Trying variant:" 1>&2
     if (( ! UID )); then
       echo "$@" 1>&2

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+arg1="$1"
 
 [ -d use -a -f use/use.py ] && cd ..
 [ -f unit_teat.py ] && cd ..
@@ -10,13 +11,14 @@ done
 export PYTHON3
 
 
-if [ "x$1" != "xupload" ]; then
+if [ "x$GITHUB_AUTH$GITHUB_PATH$GITHUB_ROOT$GITHUB_USER$GITHUB_AUTHOR$GITHUB_REPO$GITHUB_COMMIT$GITHUB_REF$GITHUB_UID$GITHUB$USERID" != "x" ]; then
   find . -regextype egrep "(" "(" -name .git -prune -false ")" -o -iregex '.*/\..*cache.*|.*cache.*/\..*' ")" -a -exec rm -vrf -- "{}" +
   rm -vrf -- ~/.justuse-python/packages
   rm  -vf -- ~/.justuse-python/registry.json
   
   yes y | $PYTHON3 -m pip install --force-reinstall --upgrade \
           -r requirements.txt
+  yes y | $PYTHON3 -m pip install --force-reinstall --upgrade pytest-cov pytest-env coverage coverage-badge
   which busybox 2>/dev/null || {
     if which apt; then
       apt install -y busybox || sudo apt install -y busybox
@@ -38,124 +40,129 @@ done
 echo "cfile=${cfile}" 1>&2
 cdir="${cfile%/?*}"
 cd "$cdir"
-
-if [ "x$1" != "xupload" ]; then
-  if [ ! -f .coveragerc ]; then
-    echo "Cannot find .coveragerc after mpving to $cdir: $(pwd)"
-    find "$( pwd )" -printf '%-12s %.10T@ %p\n' | sort -k2n
-    exit 123
-  fi
-fi
-
-if [ "x$1" != "xupload" ]; then
-    if [ "x$GITHUB_AUTH" != "x" ]; then
-        $PYTHON3 -m pip install --force-reinstall coverage \
-            pytest-cov pytest-env
-    fi
-fi
-
 set +e
-default="/home/runner/work/justuse/justuse/coverage.svg"
+BADGE_FILENAME="coverage.svg"
+default="/home/runner/work/justuse/justuse/$BADGE_FILENAME"
+f="$default"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
+if [ -d "$dir" ]; then
+  :
+else
+  default="$PWD/coverage/justuse-$BADGE_FILENAME"
+fi
+echo "default=$default" 1>&2
+file="$default"
+echo "COVERAGE_IMAGE=$COVERAGE_IMAGE" 1>&2
 file="${COVERAGE_IMAGE:-${default}}"
-COVERAGE_IMAGE="$file"
+echo "file=$file" 1>&2
+
 export COVERAGE_IMAGE
 f="$file"
 fn="${f##*/}"
 dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
 nme="${fn%.*}"
-
-if [ "x$1" == "xupload" -a -f "$file" ]; then
-    echo "Found an image to publish: [$file]" 1>&2
-    for variant in \
-        '"~/public_html/mixed/" "$file"'  \
-        ;  \
-    do
-        eval "set -- $variant"
-        cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
-               ftp.pinproject.com "$@"  )
-        echo -E "Trying variant:" 1>&2
-        command "${cmd[@]}"
-        rs=$?
-        if (( ! rs )); then
-            break
-        fi
-    done
-    [ $rs -eq 0 ] && echo "*** Image upload succeeded: $file ***" 1>&2 
-fi
+if [ ! -f "$file" ]; then
 
 # run coverage!
-if [ "x$1" != "xupload" ]; then
-    covcom=( --cov-branch \
-             --cov-report term-missing \
-             --cov-report html:coverage/ \
-             --cov-report annotate:coverage/annotated \
-             --cov-report xml:coverage/cov.xml
-    )
-    covsrc=( --cov=use --cov=use.use --cov=package_hacks )
-    
-    mkdir -p ~/.justuse-python
-    rm -rf -- ~/.justuse-python/{packages/,registry.json}
-    
-    if grep -Fqe '=[^="]+=' -- ~/.justuse-python/config.toml; then
-        echo -E "Deleting malformed config.toml ..." 1>&2
-        rm -vf -- ~/.justuse-python/config.toml
+covcom=( --cov-branch \
+        --cov-report term-missing \
+        --cov-report html:coverage/ \
+        --cov-report annotate:coverage/annotated \
+        --cov-report xml:coverage/cov.xml
+)
+covsrc=( --cov=use --cov=use.use --cov=package_hacks )
+
+mkdir -p ~/.justuse-python
+rm -rf -- ~/.justuse-python/{packages/,registry.json}
+
+if grep -Fqe '=[^="]+=' -- ~/.justuse-python/config.toml; then
+    echo -E "Deleting malformed config.toml ..." 1>&2
+    rm -vf -- ~/.justuse-python/config.toml
+fi
+
+[ -e ~/.justuse-python/config.toml.bak ] \
+  && rm -vf -- ~/.justuse-python/config.toml.bak \
+  || true
+  
+mv -vf -- ~/.justuse-python/config.toml ~/.justuse-python/config.toml.bak \
+  && echo > ~/.justuse-python/config.toml
+
+opts=( -v )
+unset DEBUG ERRORS
+for append in 1; do
+
+    if (( append > 0 )); then 
+      opts+=( --cov-append )
+      opts+=( -vv )
+      export DEBUG=1 ERRORS=1
     fi
     
-    [ -e ~/.justuse-python/config.toml.bak ] \
-      && rm -vf -- ~/.justuse-python/config.toml.bak \
-      || true
+    if (( append > 0 )); then 
+      echo -E $'\ndebug = true\n\ndebugging = true\n\n'
+    else
+      echo -E $'\ndebug = false\n\ndebugging = false\n\n'
+    fi > ~/.justuse-python/config.toml
       
-    mv -vf -- ~/.justuse-python/config.toml ~/.justuse-python/config.toml.bak \
-      && echo > ~/.justuse-python/config.toml
+    $PYTHON3 -m pytest "${covcom[@]}" "${covsrc[@]}" "${opts[@]}"
+    rs=$?
     
-    opts=( -v )
-    unset DEBUG ERRORS
-    for append in 0 1; do
-    
-        if (( append > 0 )); then 
-          opts+=( --cov-append )
-          opts+=( -vv )
-          export DEBUG=1 ERRORS=1
-        fi
-        
-        if (( append > 0 )); then 
-          echo -E $'\ndebug = true\n\ndebugging = true\n\n'
-        else
-          echo -E $'\ndebug = false\n\ndebugging = false\n\n'
-        fi > ~/.justuse-python/config.toml
-          
-        $PYTHON3 -m pytest "${covcom[@]}" "${covsrc[@]}" "${opts[@]}"
-        rs=$?
-        
-        (( rs )) && exit $rs
-    done
-    set +e
-    
-    ls -lAp --color=always
-    find "$cdir" -mindepth 2 -name ".coverage" -printf '%-12s %.10T@ %p\n' \
-      | sort -k1n | cut -c 25- | tail -n 1 \
-      | {
-         max=0
-         IFS=$'\n'; while read -r cf; do
-             f="$cf"; fn="${f##*/}"
-             dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
-             ((max += 1))
-             name=".coverage.$max"
-             (( max == 1 )) && name="${name%%[!0-9]1}"
-             echo -E "Copying cov data from $f to $( pwd )/$name" 1>&2 
-             cp -vf -- "$f" "./$name" 1>&2
-             cp -vf -- "$f" "./.coverage" 1>&2
-         done;
-       }
-    
-    
-    mkdir -p coverage
-    cp -vf -- .coverage coverage/.coverage
-    
-    [ -e ~/.justuse-python/config.toml.bak ] \
-      && mv ~/.justuse-python/config.toml.bak ~/.justuse-python/config.toml
-    
+    (( rs )) && exit $rs
+done
+set +e
+
+if [ ! -f .coveragerc ]; then
+  echo "Cannot find .coveragerc after mpving to $cdir: $(pwd)"
+  find "$( pwd )" -printf '%-12s %.10T@ %p\n' | sort -k2n
+  exit 123
 fi
+
+ls -lAp --color=always
+find "$cdir" -mindepth 2 -name ".coverage" -printf '%-12s %.10T@ %p\n' \
+  | sort -k1n | cut -c 25- | tail -n 1 \
+  | {
+    max=0
+    IFS=$'\n'; while read -r cf; do
+        f="$cf"; fn="${f##*/}"
+        dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
+        ((max += 1))
+        name=".coverage.$max"
+        (( max == 1 )) && name="${name%%[!0-9]1}"
+        echo -E "Copying cov data from $f to $( pwd )/$name" 1>&2 
+        cp -vf -- "$f" "./$name" 1>&2
+        cp -vf -- "$f" "./.coverage" 1>&2
+    done;
+  }
+
+
+mkdir -p coverage
+cp -vf -- .coverage coverage/.coverage
+
+[ -e ~/.justuse-python/config.toml.bak ] \
+  && mv ~/.justuse-python/config.toml.bak ~/.justuse-python/config.toml
+fi
+
+
+f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
+mkdir -p "$dir"
+python3 -m coverage_badge | tee "$file"
+echo "Found an image to publish: [$file]" 1>&2
+for variant in \
+    '"/public_html/mixed/$fn" "$file"'  \
+    ;  \
+do
+    eval "set -- $variant"
+    cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
+          ftp.pinproject.com "$@"  )
+    echo -E "Trying variant:" 1>&2
+    if (( ! UID )); then
+      echo "$@" 1>&2
+    fi
+    command "${cmd[@]}"
+    rs=$?
+    if (( ! rs )); then
+        break
+    fi
+done
+[ $rs -eq 0 ] && echo "*** Image upload succeeded: $file ***" 1>&2 
 
 exit ${rs:-0} # upload
 

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-arg1="$1"
 
 [ -d use -a -f use/use.py ] && cd ..
 [ -f unit_teat.py ] && cd ..
@@ -145,13 +144,7 @@ f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
 mkdir -p "$dir"
 python3 -m coverage_badge | tee "$file"
 echo "Found an image to publish: [$file]" 1>&2
-for variant in \
-    '"/public_html/mixed/$fn" "$file"'  \
-    ;  \
-do
-    eval "set -- $variant"
-    cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
-          ftp.pinproject.com "$@"  )
+cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" "/public_html/mixed/$fn" "$file" )
     echo -E "Trying variant:" 1>&2
     if (( ! UID )); then
       echo "$@" 1>&2
@@ -161,7 +154,6 @@ do
     if (( ! rs )); then
         break
     fi
-done
 [ $rs -eq 0 ] && echo "*** Image upload succeeded: $file ***" 1>&2 
 
 exit ${rs:-0} # upload

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -149,29 +149,31 @@ echo "Found an image to publish: [$file]" 1>&2
 orig_file="$file"
 BADGE_FILENAME="$( ( git remote -v | cut -f2 | sed -r -e 's~[\t ].*$~~; s~^.*\.(net|edu|com|org)[:/]~~; s~\.git$~~; s~/~-~g; ' | head -1; git branch -v -a | grep -Fe "*" | cut -d " " -f2; ) | tr -s $'\n ' '.' | sed -r -e 's~\.*$~~; s~^~coverage_~; '; echo -n ".svg"; )";
  
-for filename in "$orig_file" "$BADGE_FILENAME"; do
-    f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _dir="$dir"; f="$filename"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _fn="$fn"; f="$file"; fn="${f##*/}"
-    fn="${filename##*/}"
-    rm -vf -- "$file" || rmdir "$file"; python3 -m coverage_badge | cat -v | tee "$_dir/$_fn" | tee "$file"; 
-    for variant in \
-        '"/public_html/mixed/$fn" "$file"'  \
-        ;  \
-    do
-        eval "set -- $variant"
-        cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
-              ftp.pinproject.com "$@"  )
-        echo -E "Trying variant:" 1>&2
-        if (( ! UID )); then
-          echo "$@" 1>&2
-        fi
-        command "${cmd[@]}"
-        rs=$?
-        if (( ! rs )); then
-            break
-        fi
-    done
-done
-[ $rs -eq 0 ] && echo "*** Image upload succeeded: $file ***" 1>&2 
+if [ $( python3 -m coverage_badge | wc -c ) -gt 800 ]; then
+  for filename in "$orig_file" "$BADGE_FILENAME"; do
+      f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _dir="$dir"; f="$filename"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _fn="$fn"; f="$file"; fn="${f##*/}"
+      fn="${filename##*/}"
+      rm -vf -- "$file" || rmdir "$file"; python3 -m coverage_badge | cat -v | tee "$_dir/$_fn" | tee "$file"; 
+      for variant in \
+          '"/public_html/mixed/$fn" "$file"'  \
+          ;  \
+      do
+          eval "set -- $variant"
+          cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
+                ftp.pinproject.com "$@"  )
+          echo -E "Trying variant:" 1>&2
+          if (( ! UID )); then
+            echo "$@" 1>&2
+          fi
+          command "${cmd[@]}"
+          rs=$?
+          if (( ! rs )); then
+              break
+          fi
+      done
+  [ $rs -eq 0 ] && echo "*** Image upload succeeded: $@ ***" 1>&2 
+  done
+fi
 
 exit ${rs:-0} # upload
 

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -150,7 +150,9 @@ orig_file="$file"
 BADGE_FILENAME="$( ( git remote -v | cut -f2 | sed -r -e 's~[\t ].*$~~; s~^.*\.(net|edu|com|org)[:/]~~; s~\.git$~~; s~/~-~g; ' | head -1; git branch -v -a | grep -Fe "*" | cut -d " " -f2; ) | tr -s $'\n ' '.' | sed -r -e 's~\.*$~~; s~^~coverage_~; '; echo -n ".svg"; )";
  
 for filename in "$orig_file" "$BADGE_FILENAME"; do
+    f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _dir="$dir"; f="$filename"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _fn="$fn"; f="$file"; fn="${f##*/}"
     fn="${filename##*/}"
+    rm -vf -- "$file" || rmdir "$file"; python3 -m coverage_badge | cat -v | tee "$_dir/$_fn" | tee "$file"; 
     for variant in \
         '"/public_html/mixed/$fn" "$file"'  \
         ;  \

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -150,6 +150,7 @@ orig_file="$file"
 BADGE_FILENAME="$( ( git remote -v | cut -f2 | sed -r -e 's~[\t ].*$~~; s~^.*\.(net|edu|com|org)[:/]~~; s~\.git$~~; s~/~-~g; ' | head -1; git branch -v -a | grep -Fe "*" | cut -d " " -f2; ) | tr -s $'\n ' '.' | sed -r -e 's~\.*$~~; s~^~coverage_~; '; echo -n ".svg"; )";
  
 if [ $( python3 -m coverage_badge | wc -c ) -gt 800 ]; then
+  python3 -c "import coverage_badge" >/dev/null 2>&1 || python3 -m pip install --force-reinstall coverage-badge
   for filename in "$orig_file" "$BADGE_FILENAME"; do
       f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _dir="$dir"; f="$filename"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _fn="$fn"; f="$file"; fn="${f##*/}"
       fn="${filename##*/}"

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -92,7 +92,6 @@ for append in 1; do
     if (( append > 0 )); then 
       opts+=( --cov-append )
       opts+=( -vv )
-      export DEBUG=1 ERRORS=1
     fi
     
     if (( append > 0 )); then 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -121,7 +121,8 @@ def test_classical_install(reuse):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         mod = reuse("pytest", modes=reuse.fatal_exceptions)
-        assert mod is pytest
+        assert mod is pytest or \
+               mod._ProxyModule__implementation is pytest
         assert issubclass(w[-1].category, use.AmbiguityWarning)
 
 
@@ -173,8 +174,9 @@ def test_pure_python_package(reuse):
     # https://pypi.org/project/example-pypi-package/
     file = (
         reuse.Path.home()
-        / f".justuse-python/packages/example_pypi_package-0.1.0-py3-none-any.whl"
+        / '.justuse-python/packages/example_pypi_package-0.1.0-py3-none-any.whl'
     )
+
     file.unlink(missing_ok=True)
     test = reuse(
         "example-pypi-package.examplepy",
@@ -298,11 +300,9 @@ def test_registry(reuse):
     )
     package_name, _ = name.split(".")
     file = (
-        use.Path.home()
-        / f".justuse-python"
-        / "packages"
-        / f"{package_name.replace('-','_')}-0.1.0-py3-none-any.whl"
-    )
+        (use.Path.home() / '.justuse-python') / "packages"
+    ) / f"{package_name.replace('-','_')}-0.1.0-py3-none-any.whl"
+
     file.unlink(missing_ok=True)
     mod = reuse(
         name,
@@ -340,7 +340,7 @@ def _extracted_from_test_registry_13(jsonfile, package_name, vers, file):
     assert path.exists(), f"The package {path} did not get written."
     assert (
         path.absolute() == file.absolute()
-    ), f"The package did not get written to the expected location."
+    ), 'The package did not get written to the expected location.'
     for k, v in use._registry.items():
         jsonv = jsondata.get(k, ...)
         if isinstance(jsonv, dict) and isinstance(v, defaultdict):
@@ -528,7 +528,7 @@ def test_suggestion_works(reuse):
     except RuntimeWarning as rw:
         match = re.search(r"(use\(.*\))", str(rw))
         assert match
-        log.info(f"eval(match[1]!r)")
+        log.info('eval(match[1]!r)')
         mod = eval(match[1])
         assert mod
         return


### PR DESCRIPTION
Return ProxyModule, fix 2 jasource_dir edge cases (#160 ) (#161 )
  * Add __name__ and friends to Use module instance (#160 )
  * Make the class 'use.Use' accessible
  * Make the original module 'use.use' accessible
  * Fix null source dir encountered in REPL
  * Return ProxyModule where we return 'mod' from an instance method' (#161 )
  * Fix failing assert
  * 'Refactored by Sourcery' (#161 )

Unit Test/CI infra Tidy-ups and Fixes: (#161)
  * Fix coverage badge issues
  * Strip unnecessary code from CI workflow file
  * Address two shell script refactorings

As previously merged (via branch '83-we-should-turn-the-registry-into-an-sqlite-db'):
  * work on sqlite (#150) (#151) (#152)
  * Move code to Use, remove useless loop (#153) (#154)
  * in-memory db for testing (#155)
  * Fix _using key and self._registry = Cursor/Connection (#155)
  * Insert/ignore for duplicate hashes (#155)

Co-authored-by: Anselm Kiefner <use-github@anselm.kiefner.de>
Co-authored-by: David Reilly <greyblue9@gmail.com>
 