### PR TITLE
Revamp find_entry_point

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest-cov ~= 2.12.1
 pytest-env ~= 0.6.2
 requests >= 2.24.0
 furl >= 2.1.2
+wheel >= 0.36.2

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -514,10 +514,7 @@ def _load_venv_mod(package_name, version):
     venv_root = _venv_root(package_name, version)
     pkg_path = _venv_pkg_path(package_name, version)
     venv_bin = venv_root / "bin"
-    python_exe = Path(sys.executable).stem
-    for p in glob(os.path.join(venv_root, "**", "python.exe"), recursive=True):
-        venv_bin = Path(p).parent
-        python_exe = "python.exe"
+    python_exe = Path(sys.executable).name
     current_path = os.environ.get("PATH")
     venv_path_var = f"{venv_bin}{os.path.pathsep}{current_path}"
     if not venv_bin.exists() or not pkg_path.exists():
@@ -525,6 +522,9 @@ def _load_venv_mod(package_name, version):
             [python_exe, "-m", "venv", "--system-site-packages", venv_root],
             encoding="UTF-8",
         )
+    for p in glob(os.path.join(venv_root, "**", "python.exe"), recursive=True):
+        venv_bin = Path(p).parent
+        python_exe = "python.exe"
     pip_args = (
         venv_bin / python_exe,
         "-m",
@@ -946,7 +946,7 @@ class Use(ModuleType):
 
         with open(self.home / "config.toml") as file:
             config.update(toml.load(file))
-
+        
         config.update(test_config)
 
         if config["debugging"]:
@@ -960,7 +960,7 @@ class Use(ModuleType):
                 max_version = max(Version(version) for version in data["releases"].keys())
                 target_version = max_version
                 this_version = __version__
-                if Version(this_version) < target_version:
+                if Version(__version__) < max_version:
                     warn(
                         Message.version_warning(name, target_version, this_version),
                         VersionWarning,

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -943,7 +943,7 @@ class Use(ModuleType):
 
         with open(self.home / "config.toml") as file:
             config.update(toml.load(file))
-        
+
         config.update(test_config)
 
         if config["debugging"]:
@@ -957,7 +957,7 @@ class Use(ModuleType):
                 max_version = max(Version(version) for version in data["releases"].keys())
                 target_version = max_version
                 this_version = __version__
-                if Version(__version__) < max_version:
+                if Version(this_version) < target_version:
                     warn(
                         Message.version_warning(name, target_version, this_version),
                         VersionWarning,

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -946,7 +946,7 @@ class Use(ModuleType):
 
         with open(self.home / "config.toml") as file:
             config.update(toml.load(file))
-        
+
         config.update(test_config)
 
         if config["debugging"]:
@@ -960,7 +960,7 @@ class Use(ModuleType):
                 max_version = max(Version(version) for version in data["releases"].keys())
                 target_version = max_version
                 this_version = __version__
-                if Version(__version__) < max_version:
+                if Version(this_version) < target_version:
                     warn(
                         Message.version_warning(name, target_version, this_version),
                         VersionWarning,

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -515,15 +515,18 @@ def _load_venv_mod(package_name, version):
     pkg_path = _venv_pkg_path(package_name, version)
     venv_bin = venv_root / "bin"
     python_exe = Path(sys.executable).stem
+    for p in glob(os.path.join(venv_root, "**", "python.exe"), recursive=True):
+        venv_bin = Path(p).parent
+        python_exe = "python.exe"
     current_path = os.environ.get("PATH")
     venv_path_var = f"{venv_bin}{os.path.pathsep}{current_path}"
     if not venv_bin.exists() or not pkg_path.exists():
         check_output(
-            [python_exe, "-m", "venv", venv_root],
+            [python_exe, "-m", "venv", "--system-site-packages", venv_root],
             encoding="UTF-8",
         )
     pip_args = (
-        python_exe,
+        venv_bin / python_exe,
         "-m",
         "pip",
         "--no-python-version-warning",

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -935,7 +935,7 @@ class Use(ModuleType):
 
         with open(self.home / "config.toml") as file:
             config.update(toml.load(file))
-        
+
         config.update(test_config)
 
         if config["debugging"]:
@@ -949,7 +949,7 @@ class Use(ModuleType):
                 max_version = max(Version(version) for version in data["releases"].keys())
                 target_version = max_version
                 this_version = __version__
-                if Version(__version__) < max_version:
+                if Version(this_version) < target_version:
                     warn(
                         Message.version_warning(name, target_version, this_version),
                         VersionWarning,

--- a/src/use/use.py
+++ b/src/use/use.py
@@ -88,6 +88,7 @@ from collections import namedtuple
 from enum import Enum
 from functools import lru_cache as cache
 from functools import partial, singledispatch, update_wrapper
+from glob import glob
 from importlib import metadata
 from importlib.machinery import SourceFileLoader
 from inspect import getsource, isclass, stack
@@ -95,6 +96,7 @@ from itertools import takewhile
 from logging import DEBUG, INFO, NOTSET, WARN, StreamHandler, getLogger, root
 from operator import itemgetter
 from pathlib import Path
+from pprint import pformat
 from pkgutil import zipimporter
 from subprocess import check_output, run
 from textwrap import dedent
@@ -366,39 +368,49 @@ def get_supported() -> FrozenSet[PlatformTag]:
 
 
 @pipes
-def _find_entry_point(package_name, version):
-    pkg_path = _venv_pkg_path(package_name, version)
-    files = [*map(Path, findall(pkg_path))]
-    recs = [f for f in files if f.name == "RECORD"]
+def _find_entry_point(package_name, version) -> List[Tuple[str,str]]:
+    venv_root = _venv_root(package_name, version)
+    recs = [*map(Path, glob(os.path.join(str(venv_root), "**", "*RECORD*"), recursive=True))]
     assert recs
+    log.debug("recs=%s", pformat(recs, indent=2, width=70, compact=False))
     rec_paths = [
         f
         for f in recs
-        if f.parent.stem.replace("_", "-")[0 : f.parent.stem.find("-")] == package_name
-        and f.parent.stem[f.parent.stem.find("-") + 1 :] == version
+        if package_name.lower().replace("_", "-")
+        in f.parent.stem.lower().replace("_", "-")
+        and version in f.parent.stem
     ]
     assert rec_paths
-    rec_path = rec_paths[0]
-    contents = (
-        rec_path.read_text(encoding="UTF-8")
-        >> str.strip
-        >> str.splitlines
-        << map(lambda s: s.partition(","))
-        << map(itemgetter(0))
-        >> list
-    )
-    contents_abs = list(map(pkg_path.__truediv__, contents))
-    pkg_prefix: str
-    for c in contents_abs:
-        if c.name == "top_level.txt":
-            pkg_prefix = c.read_text(encoding="UTF-8").strip().splitlines()[0]
-            break
-    entry_suffixes = _entry_suffixes(pkg_prefix, package_name)
-    entry_path: str = None
-    for c in contents_abs:
-        if any(str(c).rfind(str(e)) != -1 for e in entry_suffixes):
-            return (pkg_prefix, c)
-    return None
+    log.debug("recs_paths=%s", pformat(rec_paths, indent=2, width=70, compact=False))
+    locations = []
+    for rec_path in rec_paths:
+        pkg_path = rec_path.parent.parent
+        contents = (
+            rec_path.read_text(encoding="UTF-8")
+            >> str.strip
+            >> str.splitlines
+            << map(lambda s: s.partition(","))
+            << map(itemgetter(0))
+            >> list
+        )
+        contents_abs = list(map(pkg_path.__truediv__, contents))
+        pkg_prefix: str
+        for c in contents_abs:
+            if c.name != "top_level.txt":
+                continue
+            pkg_prefix = (
+                c.read_text(encoding="UTF-8").strip().splitlines()[0]
+            )
+            entry_suffixes = _entry_suffixes(
+                pkg_prefix, package_name
+            )
+            entry_path: str = None
+            for c in contents_abs:
+                if any(
+                    str(c).rfind(str(e))!=-1 for e in entry_suffixes
+                ):
+                    locations.append((pkg_prefix, c))
+    return locations
 
 
 def _entry_suffixes(pkg_prefix, package_name):
@@ -451,23 +463,6 @@ def _venv_unix_path():
 
 def _venv_windows_path():
     return Path("Lib") / "site-packages"
-
-
-def _find_all_simple(path: Path):
-    return filter(Path.is_file, results)
-
-
-def findall(topdir: Path):
-    """
-    Find all files under 'topdir' and return the list of full files.
-    Unless totdir is '.', return full filenames with dir prepended.
-    """
-    return [
-        # note that on Windows, base is not absolute, but is on *nix
-        (topdir / base if not Path(base).is_absolute() else Path(base)) / file
-        for base, dirs, files in os.walk(topdir.absolute(), followlinks=True)
-        for file in files
-    ]
 
 
 def isfunction(x: Any) -> bool:
@@ -558,10 +553,13 @@ def _load_venv_mod(package_name, version):
     orig_cwd = Path.cwd()
     try:
         os.chdir(pkg_path)
-        pkg_prefix, entry_module_path = _find_entry_point(package_name, version)
-        path = entry_module_path.absolute()
-        with open(path, "rb") as f:
-            return _extracted_from__load_venv_mod_54(f, package_name, pkg_prefix, path)
+        entry_points = _find_entry_point(package_name, version)
+        for pkg_prefix, entry_module_path in entry_points:
+            path = entry_module_path.absolute()
+            with open(path, "rb") as f:
+                return _extracted_from__load_venv_mod_54(
+                    f, package_name, pkg_prefix, path
+                )
     finally:
         os.chdir(orig_cwd)
 

--- a/tests/coverage.sh
+++ b/tests/coverage.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o allexport
 arg1="$1"
 
 [ -d use -a -f use/use.py ] && cd ..
@@ -7,126 +8,90 @@ while [ ! -e requirements.txt ]; do
   cd ..
 done
 
-: ${PYTHON3:=python3}
-export PYTHON3
-
+: ${PYTHON:=python3}
+[ "x${PYTHON: 0:1}" = "x/" ] || PYTHON="$( which ""$PYTHON"" || which "python" || which "python.exe" )"
+export PYTHON
 
 if [ "x$GITHUB_AUTH$GITHUB_PATH$GITHUB_ROOT$GITHUB_USER$GITHUB_AUTHOR$GITHUB_REPO$GITHUB_COMMIT$GITHUB_REF$GITHUB_UID$GITHUB$USERID" != "x" ]; then
   find . -regextype egrep "(" "(" -name .git -prune -false ")" -o -iregex '.*/\..*cache.*|.*cache.*/\..*' ")" -a -exec rm -vrf -- "{}" +
-  rm -vrf -- ~/.justuse-python/packages
-  rm  -vf -- ~/.justuse-python/registry.json
-  
-  yes y | $PYTHON3 -m pip install --force-reinstall --upgrade \
-          -r requirements.txt
-  which busybox 2>/dev/null || {
-    if which apt; then
-      apt install -y busybox || sudo apt install -y busybox
-    fi
-  }
+  yes y | "$PYTHON" -m pip install --force-reinstall --upgrade -r requirements.txt
 fi
+which apt && ! which busybox && { apt install -y busybox || sudo apt install -y busybox; }
 
 
 echo "=== COVERAGE SCRIPT ==="
 echo "$0 running from $( pwd )"
-cdir="$( pwd )"
-cfile="$cdir/.coveragerc"
-while [ ! -e "$cfile" ]; do
-    cdir="${cfile%/?*}"
-    cdir2="${cdir%/?*}"    
-    [ "x${cfile2##/}" = "x/" ] && echo "No coveragerc" && exit 255
-    cfile="$( find "$cdir2" -mindepth 2 -maxdepth 4 -name .coveragerc )"
+coveragerc_cdir="$( pwd )"
+coveragerc_cfile="$coveragerc_cdir/.coveragerc"
+while [ ! -e "$coveragerc_cfile" ]; do
+  coveragerc_cdir="${coveragerc_cfile%/?*}"
+  coveragerc_cdir2="${coveragerc_cdir%/?*}"  
+  [ "x${coveragerc_cfile2##/}" = "x/" ] && echo "No coveragerc" && exit 255
+  coveragerc_cfile="$( find "$coveragerc_cdir2" -mindepth 2 -maxdepth 4 -name .coveragerc )"
 done
-echo "cfile=${cfile}" 1>&2
-cdir="${cfile%/?*}"
-cd "$cdir"
-set +e
-BADGE_FILENAME="coverage.svg"
+coveragerc_cdir="${coveragerc_cfile%/?*}"
+  
+echo "coveragerc_cfile=${coveragerc_cfile}" 1>&2
+echo "coveragerc_cdir=${coveragerc_cdir}" 1>&2
+! cd "$coveragerc_cdir" && echo "Failed to cd to \$coveragerc_dir [\"$coveragerc_dir\"]" 1>&2 && exit 255
+
+
+
+IFS=$'\n'; badge_urls=($( curl -ks "https://raw.githubusercontent.com/amogorkon/justuse/main/README.md" | grep -e '\[!\[coverage\]' | tr -s '()' '\n' | grep -Fe "://" | grep -Fe ".svg" )); badge_url_no_query="${badge_urls[0]%%[#\?]*}"; badge_fn="${badge_url_no_query##*/}"; BADGE_FILENAME="$badge_fn";
 default="/home/runner/work/justuse/justuse/$BADGE_FILENAME"
 f="$default"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
-if [ -d "$dir" ]; then
-  :
-else
-  default="$PWD/coverage/$BADGE_FILENAME"
-fi
-echo "default=$default" 1>&2
-file="$default"
-echo "COVERAGE_IMAGE=$COVERAGE_IMAGE" 1>&2
+[ ! -d "$dir" ] && default="$PWD/coverage/$BADGE_FILENAME"
 file="${COVERAGE_IMAGE:-${default}}"
-echo "file=$file" 1>&2
-
-export COVERAGE_IMAGE
-f="$file"
-fn="${f##*/}"
-dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
-nme="${fn%.*}"
-if [ ! -f "$file" ]; then
-
-# run coverage!
-covcom=( --cov-branch \
-        --cov-report term-missing \
-        --cov-report html:coverage/ \
-        --cov-report annotate:coverage/annotated \
-        --cov-report xml:coverage/cov.xml
-)
+f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; nme="${fn%.*}"
+covcom=( --cov-branch --cov-report term-missing --cov-report html:coverage/ --cov-report annotate:coverage/annotated --cov-report xml:coverage/cov.xml )
 covsrc=( --cov=use --cov=use.use --cov=package_hacks )
-
-mkdir -p ~/.justuse-python
-rm -rf -- ~/.justuse-python/{packages/,registry.json}
-
-if grep -Fqe '=[^="]+=' -- ~/.justuse-python/config.toml; then
-    echo -E "Deleting malformed config.toml ..." 1>&2
-    rm -vf -- ~/.justuse-python/config.toml
-fi
-
-[ -e ~/.justuse-python/config.toml.bak ] \
-  && rm -vf -- ~/.justuse-python/config.toml.bak \
-  || true
   
-mv -vf -- ~/.justuse-python/config.toml ~/.justuse-python/config.toml.bak \
-  && echo > ~/.justuse-python/config.toml
-
+echo "default=$default" 1>&2
+echo "COVERAGE_IMAGE=$COVERAGE_IMAGE" 1>&2
+echo "file=$file" 1>&2
+  
 opts=( -v )
 unset DEBUG ERRORS
 for append in 1; do
 
-    if (( append > 0 )); then 
-      opts+=( --cov-append )
-      opts+=( -vv )
-    fi
+  if (( append > 0 )); then 
+    opts+=( --cov-append )
+    opts+=( -vv )
+  fi
+  
+  if (( append > 0 )); then 
+    echo -E $'\ndebug = true\n\ndebugging = true\n\n'
+  else
+    echo -E $'\ndebug = false\n\ndebugging = false\n\n'
+  fi > ~/.justuse-python/config.toml
     
-    if (( append > 0 )); then 
-      echo -E $'\ndebug = true\n\ndebugging = true\n\n'
-    else
-      echo -E $'\ndebug = false\n\ndebugging = false\n\n'
-    fi > ~/.justuse-python/config.toml
-      
-    $PYTHON3 -m pytest "${covcom[@]}" "${covsrc[@]}" "${opts[@]}"
-    rs=$?
-    
-    (( rs )) && exit $rs
+  "$PYTHON" -m pytest "${covcom[@]}" "${covsrc[@]}" "${opts[@]}"
+  rs=$?
+  
+  (( rs )) && exit $rs
 done
 set +e
 
 if [ ! -f .coveragerc ]; then
-  echo "Cannot find .coveragerc after mpving to $cdir: $(pwd)"
+  echo "Cannot find .coveragerc after mpving to $coveragerc_cdir: $(pwd)"
   find "$( pwd )" -printf '%-12s %.10T@ %p\n' | sort -k2n
   exit 123
 fi
 
 ls -lAp --color=always
-find "$cdir" -mindepth 2 -name ".coverage" -printf '%-12s %.10T@ %p\n' \
+find "$coveragerc_cdir" -mindepth 2 -name ".coverage" -printf '%-12s %.10T@ %p\n' \
   | sort -k1n | cut -c 25- | tail -n 1 \
   | {
     max=0
-    IFS=$'\n'; while read -r cf; do
-        f="$cf"; fn="${f##*/}"
-        dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
-        ((max += 1))
-        name=".coverage.$max"
-        (( max == 1 )) && name="${name%%[!0-9]1}"
-        echo -E "Copying cov data from $f to $( pwd )/$name" 1>&2 
-        cp -vf -- "$f" "./$name" 1>&2
-        cp -vf -- "$f" "./.coverage" 1>&2
+    IFS=$'\n'; while read -r coveragerc_cf; do
+      f="$coveragerc_cf"; fn="${f##*/}"
+      dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
+      ((max += 1))
+      name=".coverage.$max"
+      (( max == 1 )) && name="${name%%[!0-9]1}"
+      echo -E "Copying cov data from $f to $( pwd )/$name" 1>&2 
+      cp -vf -- "$f" "./$name" 1>&2
+      cp -vf -- "$f" "./.coverage" 1>&2
     done;
   }
 
@@ -134,17 +99,9 @@ find "$cdir" -mindepth 2 -name ".coverage" -printf '%-12s %.10T@ %p\n' \
 mkdir -p coverage
 cp -vf -- .coverage coverage/.coverage
 
-[ -e ~/.justuse-python/config.toml.bak ] \
-  && mv ~/.justuse-python/config.toml.bak ~/.justuse-python/config.toml
-fi
-
-
-f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"
 mkdir -p "$dir"
 python3 -m coverage_badge | tee "$file"
 echo "Found an image to publish: [$file]" 1>&2
-
-
 orig_file="$file"
 
 IFS=$'\n'; remotes=($( git remote -v  | cut -f2 | cut -d: -f2 | cut -d/ -f1 | sort | uniq ))
@@ -156,29 +113,29 @@ for remote in "${remotes[@]}"; do
   badge_filenames+=( "$badge_filename" )
 done
  
-if [ $( python3 -m coverage_badge | wc -c ) -gt 800 ]; then
+if [ "x$FTP_USER" != "x" -a $( python3 -m coverage_badge | wc -c ) -gt 800 ]; then
   python3 -c "import coverage_badge" >/dev/null 2>&1 || python3 -m pip install --force-reinstall coverage-badge
   for filename in "$orig_file" "${badge_filenames[@]}"; do
-      f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _dir="$dir"; f="$filename"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _fn="$fn"; f="$file"; fn="${f##*/}"
-      fn="${filename##*/}"
-      rm -vf -- "$file" || rmdir "$file"; python3 -m coverage_badge | cat -v | tee "$_dir/$_fn" | tee "$file"; 
-      for variant in \
-          '"/public_html/mixed/$fn" "$file"'  \
-          ;  \
-      do
-          eval "set -- $variant"
-          cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
-                ftp.pinproject.com "$@"  )
-          echo -E "Trying variant:" 1>&2
-          if (( ! UID )); then
-            echo "$@" 1>&2
-          fi
-          command "${cmd[@]}"
-          rs=$?
-          if (( ! rs )); then
-              break
-          fi
-      done
+    f="$file"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _dir="$dir"; f="$filename"; fn="${f##*/}"; dir="${f: 0:${#f}-${#fn}}"; dir="${dir%%/}"; _fn="$fn"; f="$file"; fn="${f##*/}"
+    fn="${filename##*/}"
+    rm -vf -- "$file" || rmdir "$file"; python3 -m coverage_badge | cat -v | tee "$_dir/$_fn" | tee "$file"; 
+    for variant in \
+      '"/public_html/mixed/$fn" "$file"'  \
+      ;  \
+    do
+      eval "set -- $variant"
+      cmd=(  busybox ftpput -v -P 21 -u "$FTP_USER" -p "$FTP_PASS" \
+        ftp.pinproject.com "$@"  )
+      echo -E "Trying variant:" 1>&2
+      if (( ! UID )); then
+      echo "$@" 1>&2
+      fi
+      command "${cmd[@]}"
+      rs=$?
+      if (( ! rs )); then
+        break
+      fi
+    done
   [ $rs -eq 0 ] && echo "*** Image upload succeeded: $@ ***" 1>&2 
   done
 fi

--- a/tests/tdd_test.py
+++ b/tests/tdd_test.py
@@ -76,9 +76,6 @@ def test_is_platform_compatible_win(reuse):
     assert reuse._is_platform_compatible(info, platform_tags, include_sdist=False)
     
 
-@pytest.mark.skipif(
-    is_win, reason="Finding Windows RECORD files in development"
-)
 def test_pure_python_package(reuse):
     # https://pypi.org/project/example-pypi-package/
     file = (
@@ -112,16 +109,10 @@ def _do_load_venv_mod(reuse, package, version=None):
     assert mod.__version__ == version
 
 
-@pytest.mark.skipif(
-    is_win, reason="Finding Windows RECORD files in development"
-)
 def test_load_venv_mod_protobuf(reuse):
     _do_load_venv_mod(reuse, "protobuf")
 
 
-@pytest.mark.skipif(
-    is_win, reason="Finding Windows RECORD files in development"
-)
 def test_load_venv_mod_numpy(reuse):
     _do_load_venv_mod(reuse, "numpy", "1.19.3")
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -382,9 +382,6 @@ def test_reloading(reuse):
                 pass
 
 
-@pytest.mark.skipif(
-    is_win, reason="Finding Windows RECORD files in development"
-)
 def test_suggestion_works(reuse):
     sugg = suggested_artifact("example-pypi-package.examplepy")
     mod = reuse(


### PR DESCRIPTION
- Fixes auto-install for Windows, hopefully
- Removes findall() and _find_all_simple() in favor of glob.glob()
- Add some logging